### PR TITLE
More free summary texts

### DIFF
--- a/src/locales/de/summary-ui-handler.ts
+++ b/src/locales/de/summary-ui-handler.ts
@@ -4,10 +4,9 @@ export const SummaryUiHandler: SimpleTranslationEntries = {
     "pokemonInfo": "Pokémon Info", //Currently unused
     "originalTrainer": "OT",
     "type": "Typ",
-    "natureBeforeText": "Wesen: ",
-    "natureAfterText": "",
-    "apparently": "Wahrscheinlich",
-    "metAtLv":"getroffen auf Lvl. ",
+    "memoText": "Wesen: {{nature}},\n{{metText}} auf Lvl. {{level}},\n{{biomeName}}.",
+    "memoMet": "getroffen",
+    "memoApparentlyMet": "Wahrscheinlich getroffen",
     "status": "Status",
     "lvl": "Lvl",
     "unknown": 'Unbekannt',

--- a/src/locales/en/party-ui-handler.ts
+++ b/src/locales/en/party-ui-handler.ts
@@ -15,7 +15,7 @@ export const partyUiHandler: SimpleTranslationEntries = {
     "RELEASE": "Release",
     "CANCEL": "Cancel",
     "unpauseEvolution": "Evolutions have been unpaused for {{pokemonName}}",
-    "unsplicePokemon": "`Do you really want to unsplice {{fusionSpeciesName}}\nfrom {{pokemonName}? {{fusionSpeciesName}} will be lost.",
+    "unsplicePokemon": "Do you really want to unsplice {{fusionSpeciesName}}\nfrom {{pokemonName}}? {{fusionSpeciesName}} will be lost.",
     "spliceRevertText": "{{fusionName}} was reverted to {{pokemonName}}.",
     "releasePokemon": "Do you really want to release {{pokemonName}}?",
 

--- a/src/locales/en/summary-ui-handler.ts
+++ b/src/locales/en/summary-ui-handler.ts
@@ -4,10 +4,9 @@ export const SummaryUiHandler: SimpleTranslationEntries = {
     "pokemonInfo": "Pokémon Info", //Currently unused
     "originalTrainer": "OT",
     "type": "Type",
-    "natureBeforeText": "",
-    "natureAfterText": " nature",
-    "apparently": "apparently",
-    "metAtLv":"met at Lv",
+    "memoText": "{{nature}} nature,\n{{metText}} at Lv{{level}},\n{{biomeName}}.",
+    "memoMet": "met",
+    "memoApparentlyMet": "apparently met",
     "status": "Status",
     "lvl": "Lvl",
     "unknown": 'Unknown',

--- a/src/locales/es/summary-ui-handler.ts
+++ b/src/locales/es/summary-ui-handler.ts
@@ -4,10 +4,9 @@ export const SummaryUiHandler: SimpleTranslationEntries = {
     "pokemonInfo": "Info. Pokémon", //Currently unused
     "originalTrainer": "EO",
     "type": "Tipo",
-    "natureBeforeText": "Naturaleza: ",
-    "natureAfterText": "",
-    "apparently": "aparentemente",
-    "metAtLv":"encontrado con Nv. ",
+    "memoText": "Naturaleza: {{nature}},\n{{metText}} con Nv. {{level}},\n{{biomeName}}.",
+    "memoMet": "encontrado",
+    "memoApparentlyMet": "aparentemente encontrado",
     "status": "Estado",
     "lvl": "Nv",
     "unknown": "Desconocido",

--- a/src/locales/fr/summary-ui-handler.ts
+++ b/src/locales/fr/summary-ui-handler.ts
@@ -4,10 +4,9 @@ export const SummaryUiHandler: SimpleTranslationEntries = {
     "pokemonInfo": "Info Pokémon", //Currently unused
     "originalTrainer": "DO",
     "type": "Type",
-    "natureBeforeText": "",
-    "natureAfterText": " de nature",
-    "apparently": "apparemment",
-    "metAtLv":"rencontré au N.",
+    "memoText": "{{nature}} de nature,\n{{metText}} au N.{{level}},\n{{biomeName}}.",
+    "memoMet": "rencontré",
+    "memoApparentlyMet": "apparemment rencontré",
     "status": "Statut",
     "lvl": "N.",
     "unknown": 'Inconnu',

--- a/src/locales/it/summary-ui-handler.ts
+++ b/src/locales/it/summary-ui-handler.ts
@@ -4,10 +4,9 @@ export const SummaryUiHandler: SimpleTranslationEntries = {
     "pokemonInfo": "Pokémon Info", //Currently unused
     "originalTrainer": "OT",
     "type": "Type",
-    "natureBeforeText": "",
-    "natureAfterText": " nature",
-    "apparently": "apparently",
-    "metAtLv":"met at Lv",
+    "memoText": "{{nature}} nature,\n{{metText}} at Lv{{level}},\n{{biomeName}}.",
+    "memoMet": "met",
+    "memoApparentlyMet": "apparently met",
     "status": "Status",
     "lvl": "Lvl",
     "unknown": 'Unknown',

--- a/src/locales/pt_BR/summary-ui-handler.ts
+++ b/src/locales/pt_BR/summary-ui-handler.ts
@@ -4,10 +4,9 @@ export const SummaryUiHandler: SimpleTranslationEntries = {
     "pokemonInfo": "Pokémon Info", //Currently unused
     "originalTrainer": "OT",
     "type": "Type",
-    "natureBeforeText": "",
-    "natureAfterText": " nature",
-    "apparently": "apparently",
-    "metAtLv":"met at Lv",
+    "memoText": "{{nature}} nature,\n{{metText}} at Lv{{level}},\n{{biomeName}}.",
+    "memoMet": "met",
+    "memoApparentlyMet": "apparently met",
     "status": "Status",
     "lvl": "Lvl",
     "unknown": 'Unknown',

--- a/src/locales/zh_CN/summary-ui-handler.ts
+++ b/src/locales/zh_CN/summary-ui-handler.ts
@@ -4,10 +4,9 @@ export const SummaryUiHandler: SimpleTranslationEntries = {
     "pokemonInfo": "Pokémon Info", //Currently unused
     "originalTrainer": "OT",
     "type": "Type",
-    "natureBeforeText": "",
-    "natureAfterText": " nature",
-    "apparently": "apparently",
-    "metAtLv":"met at Lv",
+    "memoText": "{{nature}} nature,\n{{metText}} at Lv{{level}},\n{{biomeName}}.",
+    "memoMet": "met",
+    "memoApparentlyMet": "apparently met",
     "status": "Status",
     "lvl": "Lvl",
     "unknown": 'Unknown',

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -682,7 +682,7 @@ export default class SummaryUiHandler extends UiHandler {
         const profileContainer = this.scene.add.container(0, -pageBg.height);
         pageContainer.add(profileContainer);
 
-        const trainerText = i18next.t('summaryUiHandler:originalTrainer') as string
+        const trainerText = getBBCodeFrag(i18next.t('summaryUiHandler:originalTrainer'), TextStyle.SUMMARY_ALT, this.scene.uiTheme)
           + "/ " + getBBCodeFrag(
             loggedInUser?.username || i18next.t('summaryUiHandler:unknown'),
             this.scene.gameData.gender === PlayerGender.Female? TextStyle.SUMMARY_PINK: TextStyle.SUMMARY_BLUE

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -682,14 +682,14 @@ export default class SummaryUiHandler extends UiHandler {
         const profileContainer = this.scene.add.container(0, -pageBg.height);
         pageContainer.add(profileContainer);
 
-        const trainerLabel = addTextObject(this.scene, 7, 12, `${i18next.t('summaryUiHandler:originalTrainer') as string}/`, TextStyle.SUMMARY_ALT);
+        const trainerText = i18next.t('summaryUiHandler:originalTrainer') as string
+          + "/ " + getBBCodeFrag(
+            loggedInUser?.username || i18next.t('summaryUiHandler:unknown'),
+            this.scene.gameData.gender === PlayerGender.Female? TextStyle.SUMMARY_PINK: TextStyle.SUMMARY_BLUE
+          );
+        const trainerLabel = addBBCodeTextObject(this.scene, 7, 12, trainerText, TextStyle.SUMMARY_ALT);
         trainerLabel.setOrigin(0, 0);
         profileContainer.add(trainerLabel);
-
-        const trainerText = addTextObject(this.scene, 25, 12, loggedInUser?.username || i18next.t('summaryUiHandler:unknown'),
-          this.scene.gameData.gender === PlayerGender.FEMALE ? TextStyle.SUMMARY_PINK : TextStyle.SUMMARY_BLUE);
-        trainerText.setOrigin(0, 0);
-        profileContainer.add(trainerText);
 
         const trainerIdText = addTextObject(this.scene, 174, 12, this.scene.gameData.trainerId.toString(), TextStyle.SUMMARY_ALT);
         trainerIdText.setOrigin(0, 0);
@@ -700,7 +700,7 @@ export default class SummaryUiHandler extends UiHandler {
         profileContainer.add(typeLabel);
 
         const getTypeIcon = (index: integer, type: Type, tera: boolean = false) => {
-          const xCoord = 39 + 34 * index;
+          const xCoord = typeLabel.width * typeLabel.scale + 9 + 34 * index;
           const typeIcon = !tera
             ? this.scene.add.sprite(xCoord, 42, `types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ''}`, Type[type].toLowerCase())
             : this.scene.add.sprite(xCoord, 42, 'type_tera');

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -801,8 +801,18 @@ export default class SummaryUiHandler extends UiHandler {
         this.passiveContainer?.descriptionText.setVisible(false);
 
         let readableNature = Utils.toReadableString(Nature[this.pokemon.getNature()]);
+        let natureAfter = i18next.exists(`nature:${readableNature}After`)? i18next.t(`nature:${readableNature}After`): "";
         let biomeName = getBiomeName(this.pokemon.metBiome);
-        let memoString = `${getBBCodeFrag(`${i18next.t('summaryUiHandler:natureBeforeText')  as string}`, TextStyle.WINDOW_ALT)}${getBBCodeFrag(i18next.exists(`nature:${readableNature}`) ? i18next.t(`nature:${readableNature}`) : readableNature, TextStyle.SUMMARY_RED)}${getBBCodeFrag(`${i18next.t('summaryUiHandler:natureAfterText') as string},`, TextStyle.WINDOW_ALT)}\n${getBBCodeFrag(`${this.pokemon.metBiome === -1 ? `${i18next.t('summaryUiHandler:apparently') as string} ` : ''}${i18next.t('summaryUiHandler:metAtLv') as string}`, TextStyle.WINDOW_ALT)}${getBBCodeFrag(this.pokemon.metLevel.toString(), TextStyle.SUMMARY_RED)}${getBBCodeFrag(',', TextStyle.WINDOW_ALT)}\n${getBBCodeFrag(i18next.exists(`biome:${biomeName}`) ? i18next.t(`biome:${biomeName}`) : biomeName, TextStyle.SUMMARY_RED)}${getBBCodeFrag('.', TextStyle.WINDOW_ALT)}`;
+        let closeFrag = getBBCodeFrag("", TextStyle.WINDOW_ALT);
+        let memoString = i18next.t("summaryUiHandler:memoText", {
+          nature: getBBCodeFrag(i18next.t(`nature:${readableNature}`), TextStyle.SUMMARY_RED) + closeFrag + natureAfter,
+          metText: i18next.t(`summaryUiHandler:memo${this.pokemon.metBiome === -1? "Apparently": ""}Met`),
+          level: getBBCodeFrag(this.pokemon.metLevel.toString(), TextStyle.SUMMARY_RED) + closeFrag,
+          biomeName: getBBCodeFrag(
+            i18next.exists(`biome:${biomeName}`)? i18next.t(`biome:${biomeName}`): biomeName,
+            TextStyle.SUMMARY_RED
+          ) + closeFrag,
+        });
         const memoText = addBBCodeTextObject(this.scene, 7, 113, memoString, TextStyle.WINDOW_ALT);
         memoText.setOrigin(0, 0);
         profileContainer.add(memoText);


### PR DESCRIPTION
I don't know you like this PR but I'll try.

---
![summary1](https://github.com/rnicar245/pokerogue-esp2/assets/87186129/b6a946ad-8fb9-47bf-9c8c-ba7878e32c51)

1.
Trainer name and type marker of profile in pokemon summary no longer have a fixed position.
Since `originalTrainer` of Korean(not merged...) and `type` of Japanese(closed now...) are 6-width,
I think it can help someday.

2.
Some languages can have totally different words order in trainer memo.
English: `{{nature}}` nature, `{{apparently}}` met in Lv.`{{level}}`, `{{biome}}`.
Korean: `{{nature}}` `{{postposition-depends-on-nature}}` nature. `{{biome}}`, `\n`Lv.`{{level}}` we `{{met-or-apparently-met}}`.

I packed altogether into one object not to make problem.
We can use `"hardyAfter"`, `"LonelyAfter"`... in `locales/*/nature.ts` for `{{postposition-depends-on-nature}}`.

3.
Last commit is a simple typo fix.